### PR TITLE
Delayed unused IP address cleanup.

### DIFF
--- a/pkg/ipamd/datastore/data_store.go
+++ b/pkg/ipamd/datastore/data_store.go
@@ -34,6 +34,9 @@ const (
 	// in addressCoolingPeriod
 	addressCoolingPeriod = 30 * time.Second
 
+	// addressDelayedReleasePeriod is used to release unused IP after a period of inactivity.
+	addressDelayedReleasePeriod = 10 * time.Minute
+
 	// DuplicatedENIError is an error when caller tries to add an duplicate ENI to data store
 	DuplicatedENIError = "data store: duplicate ENI"
 
@@ -235,10 +238,10 @@ func (cidr *CidrInfo) AssignedIPAddressesInCidr() int {
 	}
 	return count
 }
-
 type CidrStats struct {
 	AssignedIPs int
 	CooldownIPs int
+	DelayedReleaseIPs int
 }
 
 // Gets number of assigned IPs and the IPs in cooldown from a given CIDR
@@ -249,6 +252,8 @@ func (cidr *CidrInfo) GetIPStatsFromCidr() CidrStats {
 			stats.AssignedIPs++
 		} else if addr.inCoolingPeriod() {
 			stats.CooldownIPs++
+		} else if addr.inDelayedReleasePeriod() {
+			stats.DelayedReleaseIPs++
 		}
 	}
 	return stats
@@ -256,12 +261,17 @@ func (cidr *CidrInfo) GetIPStatsFromCidr() CidrStats {
 
 // Assigned returns true iff the address is allocated to a pod/sandbox.
 func (addr AddressInfo) Assigned() bool {
-	return !addr.IPAMKey.IsZero()
+	return !addr.IPAMKey.IsZero() || !addr.inDelayedReleasePeriod()
 }
 
 // InCoolingPeriod checks whether an addr is in addressCoolingPeriod
 func (addr AddressInfo) inCoolingPeriod() bool {
 	return time.Since(addr.UnassignedTime) <= addressCoolingPeriod
+}
+
+// InDelayedRelease checks whether an addr is in addressDelayedReleasePeriod
+func (addr AddressInfo) inDelayedReleasePeriod() bool {
+	return time.Since(addr.UnassignedTime) <= addressDelayedReleasePeriod
 }
 
 // ENIPool is a collection of ENI, keyed by ENI ID
@@ -846,15 +856,17 @@ type DataStoreStats struct {
 	AssignedIPs int
 	// Number of addresses in cooldown
 	CooldownIPs int
+	// Number of addresses in delayed release state
+	DelayedReleaseIPs int
 }
 
 func (stats *DataStoreStats) String() string {
-	return fmt.Sprintf("Total IPs/Prefixes = %d/%d, AssignedIPs/CooldownIPs: %d/%d,",
-		stats.TotalIPs, stats.TotalPrefixes, stats.AssignedIPs, stats.CooldownIPs)
+	return fmt.Sprintf("Total IPs/Prefixes = %d/%d, AssignedIPs/CooldownIPs/DelayedReleaseIPs: %d/%d/%d,",
+		stats.TotalIPs, stats.TotalPrefixes, stats.AssignedIPs, stats.CooldownIPs, stats.DelayedReleaseIPs)
 }
 
 func (stats *DataStoreStats) AvailableAddresses() int {
-	return stats.TotalIPs - stats.AssignedIPs
+	return stats.TotalIPs - stats.AssignedIPs - stats.CooldownIPs
 }
 
 // GetStats returns DataStoreStats for addressFamily
@@ -875,6 +887,7 @@ func (ds *DataStore) GetStats(addressFamily string) DataStoreStats {
 				cidrStats := cidr.GetIPStatsFromCidr()
 				stats.AssignedIPs += cidrStats.AssignedIPs
 				stats.CooldownIPs += cidrStats.CooldownIPs
+				stats.DelayedReleaseIPs += cidrStats.DelayedReleaseIPs
 				stats.TotalIPs += cidr.Size()
 			} else if addressFamily == "6" {
 				stats.AssignedIPs += cidr.AssignedIPAddressesInCidr()

--- a/pkg/ipamd/datastore/data_store_test.go
+++ b/pkg/ipamd/datastore/data_store_test.go
@@ -396,6 +396,7 @@ func TestGetStats(t *testing.T) {
 			TotalIPs:    2,
 			AssignedIPs: 1,
 			CooldownIPs: 0,
+			DelayedReleaseIPs: 1,
 		},
 		ds.GetStats("4"),
 	)

--- a/pkg/ipamd/ipamd.go
+++ b/pkg/ipamd/ipamd.go
@@ -702,7 +702,7 @@ func (c *IPAMContext) tryFreeENI() {
 	}
 }
 
-// tryUnassignIPsorPrefixesFromAll determines if there are IPs to free when we have extra IPs beyond the target and warmIPTargetDefined
+// tryUnassignCidrsFromAll determines if there are IPs to free when we have extra IPs beyond the target and warmIPTargetDefined
 // is enabled, deallocate extra IP addresses
 func (c *IPAMContext) tryUnassignCidrsFromAll() {
 


### PR DESCRIPTION
NOTE: this change is stacked on top of https://github.com/aws/amazon-vpc-cni-k8s/pull/1704

What type of PR is this?: feature
Which issue does this PR fix: #1700
What does this PR do / Why do we need it: TODO
Testing done on this change: IN PROGRESS
Automation added to e2e: No
Will this break upgrades or downgrades. Has updating a running cluster been tested?: No/No
Does this change require updates to the CNI daemonset config files to work?: No
Does this PR introduce any user-facing change?: N

Free IP addresses are released with a 10-minute delay to avoid unnecessary churn on loaded nodes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.